### PR TITLE
Revert "Remove deprecated `forUseAtConfigurationTime` usages"

### DIFF
--- a/src/main/java/org/ajoberstar/gradle/stutter/StutterPlugin.java
+++ b/src/main/java/org/ajoberstar/gradle/stutter/StutterPlugin.java
@@ -105,6 +105,7 @@ public class StutterPlugin implements Plugin<Project> {
 
   private Map<String, Set<GradleVersion>> getLockedVersions(Project project, StutterExtension stutter) {
     var lockFile = stutter.getLockFile()
+        .forUseAtConfigurationTime()
         .get()
         .getAsFile();
 
@@ -115,7 +116,8 @@ public class StutterPlugin implements Plugin<Project> {
     }
 
     var lockFileBytes = project.getProviders().fileContents(stutter.getLockFile())
-        .getAsBytes();
+        .getAsBytes()
+        .forUseAtConfigurationTime();
 
     try (var inputStream = new ByteArrayInputStream(lockFileBytes.get());
         var reader = new BufferedReader(new InputStreamReader(inputStream))) {


### PR DESCRIPTION
Reverts ajoberstar/gradle-stutter#33

Removing this broke compatibility with earlier versions of Gradle. Not interested in doing that at this time. When Gradle 9 comes out, it'll make sense.